### PR TITLE
feat: Add consumables for permanent stat boosts

### DIFF
--- a/game_data.json
+++ b/game_data.json
@@ -1917,6 +1917,22 @@
       "shop_price": 250
     },
     {
+      "name": "Potion of Power",
+      "type": "consumable",
+      "effect_type": "stat_boost",
+      "effect_value": { "stat": "attack_power", "amount": 1 },
+      "description": "A shimmering potion that permanently increases your attack power.",
+      "shop_price": 150
+    },
+    {
+      "name": "Vitality Draught",
+      "type": "consumable",
+      "effect_type": "stat_boost",
+      "effect_value": { "stat": "max_hp", "amount": 10 },
+      "description": "A thick, red liquid that permanently increases your maximum HP.",
+      "shop_price": 200
+    },
+    {
       "name": "Amulet of Protection",
       "type": "armor",
       "subtype": "cloak",

--- a/infinitedungeon.py
+++ b/infinitedungeon.py
@@ -1877,6 +1877,11 @@ def game_loop(player_hp, max_hp, player_inventory, current_room, current_max_inv
                     if 'attack_power' in stat_changes:
                         player_attack_power += stat_changes['attack_power']
                         print(f"Your base attack power has permanently increased by {stat_changes['attack_power']}!")
+                    elif 'max_hp' in stat_changes:
+                        hp_increase = stat_changes['max_hp']
+                        max_hp += hp_increase
+                        player_hp += hp_increase
+                        print(f"Your maximum HP has permanently increased by {hp_increase}!")
 
                 if player_hp <= 0:
                     print("\n" + "=" * 40)


### PR DESCRIPTION
This commit introduces new consumable items that permanently increase the player's stats.

- Added "Potion of Power" to permanently increase attack power.
- Added "Vitality Draught" to permanently increase maximum HP.
- Updated the game loop to handle the `max_hp` increase from consumables, which also heals the player for the same amount.